### PR TITLE
Ajuste no redirection

### DIFF
--- a/src/Cadastro/DZA.Cadastro.Api/Extensions/ApiConfig.cs
+++ b/src/Cadastro/DZA.Cadastro.Api/Extensions/ApiConfig.cs
@@ -23,7 +23,7 @@ public static class ApiConfig
         if (env.IsDevelopment() || env.IsEnvironment("Stage") || env.IsEnvironment("Docker"))
             app.UseDeveloperExceptionPage();
 
-        if (app.Configuration["USE_HTTOPS_REDIRECTION"] == "true")
+        if (app.Configuration["USE_HTTPS_REDIRECTION"] == "true")
             app.UseHttpsRedirection();
 
         app.UseRouting();


### PR DESCRIPTION
#### PR Classification
Bug fix to correct a configuration key typo.

#### PR Summary
Fixes a typo in the configuration key to ensure proper HTTPS redirection functionality.
- Corrected "USE_HTTOPS_REDIRECTION" to "USE_HTTPS_REDIRECTION" in the configuration file.
